### PR TITLE
Add overrideByKey strategy

### DIFF
--- a/jsonmerge/__init__.py
+++ b/jsonmerge/__init__.py
@@ -115,6 +115,7 @@ class Merger(object):
         "version": strategies.Version(),
         "append": strategies.Append(),
         "objectMerge": strategies.ObjectMerge(),
+        "overwriteByKey": strategies.OverwriteByKey()
     }
 
     def __init__(self, schema, strategies=()):

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -333,6 +333,109 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, "foo")
 
+    def test_override_with_key(self):
+        schema = {
+            "properties": {
+                "awards": {
+                    "type": "array",
+                    "mergeStrategy": "overwriteByKey",
+                    "mergeOptions": {"match_key": "id"},
+                    "items": {
+                        "properties": {
+                            "id": {"type": "string"},
+                            "field": {"type": "number"},
+                        }
+                    }
+                }
+            }
+        }
+
+        a = {
+            "awards": [
+                {"id": "A", "field": 1},
+                {"id": "B", "field": 2}
+            ]
+        }
+
+        b = {
+            "awards": [
+                {"id": "B", "field": 3},
+                {"id": "C", "field": 4}
+            ]
+        }
+
+        expected = {
+            "awards": [
+                {"id": "A", "field": 1},
+                {"id": "B", "field": 3},
+                {"id": "C", "field": 4}
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+
+        base = None
+        base = merger.merge(base, a)
+        base = merger.merge(base, b)
+
+        self.assertEqual(base, expected)
+
+    def test_override_with_key_with_complex_array(self):
+        schema = {
+            "properties": {
+                "awards": {
+                    "type": "array",
+                    "mergeStrategy": "overwriteByKey",
+                    "mergeOptions": {"match_key": "id"},
+                    "items": {
+                        "properties": {
+                            "id": {"type": "string"},
+                            "field": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "xx": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        a = {
+            "awards": [
+                {"id": "A", "field": [{"xx": "testA1"}, {"xx": "testA2"}]},
+                {"id": "B", "field": [{"xx": "testA3"}, {"xx": "testA4"}]}
+            ]
+        }
+
+        b = {
+            "awards": [
+                {"id": "B", "field": [{"xx": "testA3"}, {"xx": "testA6"}]},
+                {"id": "C", "field": [{"xx": "testA7"}, {"xx": "testA8"}]}
+            ]
+        }
+
+        expected = {
+            "awards": [
+                {"id": "A", "field": [{"xx": "testA1"}, {"xx": "testA2"}]},
+                {"id": "B", "field": [{"xx": "testA3"}, {"xx": "testA6"}]},
+                {"id": "C", "field": [{"xx": "testA7"}, {"xx": "testA8"}]}
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+
+        base = None
+        base = merger.merge(base, a)
+        base = merger.merge(base, b)
+
+        self.assertEqual(base, expected)
+
 
 class TestGetSchema(unittest.TestCase):
 


### PR DESCRIPTION
This seems like a generally useful merge strategy. Allows you to handle lists slightly more carefully. Only does default merge on list objects i.e. currently does not go and retrieve subschema.
