### PR TITLE
Add failing test for type: "array" not on version schema

### DIFF
--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -624,3 +624,53 @@ class TestGetSchema(unittest.TestCase):
             }
 
         self.assertEqual(d, mschema)
+
+    def test_version_adds_array_type(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "buyer": {
+                    "properties": {
+                        "id": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "mergeStrategy": "version"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expected = {
+            "type": "object",
+            "properties": {
+                "buyer": {
+                    "properties": {
+                        "id": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "value": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        merger = jsonmerge.Merger(schema)
+        schema2 = merger.get_schema()
+
+        self.assertEqual(schema2, expected)


### PR DESCRIPTION
I can see that this is tricky, otherwise would have fixed it myself, but I think we should have array type on version.
