### PR TITLE
Array merge by id schema generation

### DIFF
--- a/jsonmerge/strategies.py
+++ b/jsonmerge/strategies.py
@@ -171,7 +171,12 @@ class ArrayMergeById(Strategy):
         return base
 
     def get_schema(self, walk, schema, meta, **kwargs):
-        return walk.resolve_refs(schema)
+        subschema = None
+        if schema:
+            subschema = schema.get('items')
+
+        schema2 = walk.descend(subschema, meta)
+        return schema
 
 
 class ObjectMerge(Strategy):

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -1154,6 +1154,113 @@ class TestGetSchema(unittest.TestCase):
             }
         }
 
+        merger = jsonmerge.Merger(schema)
+        schema2 = merger.get_schema()
+
+        self.assertEqual(schema2, expected)
+
+    def test_merge_by_id_with_depth(self):
+
+        schema = {
+            "properties": {
+                "test": {
+                    "mergeStrategy": "arrayMergeById",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/refitem"
+                    }
+                }
+            },
+            "definitions": {
+                "refitem": {
+                    "type": "object",
+                    "properties": {
+                        "field1": {
+                            "type": "string",
+                            "mergeStrategy": "version"
+                        }
+                    }
+                }
+            }
+        }
+
+        expected = {
+            "properties": {
+                "test": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/refitem"
+                    }
+                }
+            },
+            "definitions": {
+                "refitem": {
+                    "type": "object",
+                    "properties": {
+                        "field1": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.maxDiff = None
+
+        merger = jsonmerge.Merger(schema)
+        schema2 = merger.get_schema()
+
+        self.assertEqual(schema2, expected)
+
+    def test_merge_by_id_with_depth_no_ref(self):
+
+        schema = {
+            "properties": {
+                "test": {
+                    "mergeStrategy": "arrayMergeById",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field1": {
+                                "type": "string",
+                                "mergeStrategy": "version"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        expected = {
+            "properties": {
+                "test": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field1": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        self.maxDiff = None
 
         merger = jsonmerge.Merger(schema)
         schema2 = merger.get_schema()


### PR DESCRIPTION
Hi,

Schema generation on arrayMergeById wasn't quite right. The full problem I was trying to solve you can see here: https://github.com/open-contracting/standard/commit/21047065367cc51000d10a5219cb4b8a2b246eed I think the tests captured it. Things seem to be working as I expect now although I have to confess I'm not entirely sure I understand why!
