### PR TITLE
Allow versioning on referenced items.

### DIFF
--- a/jsonmerge/__init__.py
+++ b/jsonmerge/__init__.py
@@ -13,15 +13,15 @@ class Walk(object):
 
     def descend(self, schema, *args):
         if schema is not None:
+            name = schema.get("mergeStrategy")
+            opts = schema.get("mergeOptions")
+            if opts is None:
+                opts = {}
+
             ref = schema.get("$ref")
-            if ref is not None:
+            if name is None and ref is not None:
                 with self.resolver.resolving(ref) as resolved:
                     return self.descend(resolved, *args)
-            else:
-                name = schema.get("mergeStrategy")
-                opts = schema.get("mergeOptions")
-                if opts is None:
-                    opts = {}
         else:
             name = None
             opts = {}
@@ -196,7 +196,7 @@ class Merger(object):
         walk = WalkSchema(self)
         return walk.descend(self.schema, meta)
 
-def merge(base, head, schema={}):
+def merge(base, head, schema=None):
     """Merge two JSON documents using strategies defined in schema.
 
     base -- Old JSON document you are merging into.
@@ -208,6 +208,7 @@ def merge(base, head, schema={}):
     strategy is to use "objectMerge" for objects and "overwrite"
     for all other types.
     """
-
+    if not schema:
+        schema = {}
     merger = Merger(schema)
     return merger.merge(base, head)

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -116,6 +116,71 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, [{'value': "b"}])
 
+    def test_version_on_ref_with_list(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "mergeStrategy": "version",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/item"
+                    }
+                }
+            },
+            "definitions": {
+                "item": {
+                    "type": "string"
+                }
+            }
+        }
+
+        a = {"item": ["test"]}
+        b = {"item": ["test2"]}
+
+        expected_base = {
+            "item": [
+                {"value": ["test"]},
+                {"value": ["test2"]}
+            ]
+        }
+
+        base = None
+        base = jsonmerge.merge(base, a, schema)
+        base = jsonmerge.merge(base, b, schema)
+        self.assertEqual(expected_base, base)
+
+    def test_version_on_ref(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "mergeStrategy": "version",
+                    "$ref": "#/definitions/item"
+                }
+            },
+            "definitions": {
+                "item": {
+                    "type": "string"
+                }
+            }
+        }
+
+        a = {"item": "test"}
+        b = {"item": "test2"}
+
+        expected_base = {
+            "item": [
+                {"value": "test"},
+                {"value": "test2"}
+            ]
+        }
+
+        base = None
+        base = jsonmerge.merge(base, a, schema)
+        base = jsonmerge.merge(base, b, schema)
+        self.assertEqual(expected_base, base)
+
     def test_append(self):
 
         schema = {'mergeStrategy': 'append'}


### PR DESCRIPTION
I wanted to be able to do something like:

```
"properties": {
    "item": {
        "mergeStrategy": "version",
        "$ref": "#/definitions/item"
 }
```

but in descend, the mergeStrategy was getting thrown away if a ref was present.
