### PR TITLE
fix for handling additionalProperties keyword and update test

### DIFF
--- a/jsonmerge/strategies.py
+++ b/jsonmerge/strategies.py
@@ -229,7 +229,7 @@ class ObjectMerge(Strategy):
                 if subschema.is_undef():
                     p = schema.get('additionalProperties')
                     if not p.is_undef():
-                        subschema = p.get(k)
+                        subschema = p
 
             base.val[k] = walk.descend(subschema, base.get(k), v, meta).val
 

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -239,8 +239,11 @@ class TestMerge(unittest.TestCase):
     def test_merge_append_additional(self):
 
         schema = {'mergeStrategy': 'objectMerge',
+                  'properties': {
+                      'b': {'mergeStrategy': 'overwrite'}
+                  },
                   'additionalProperties': {
-                      'a': {'mergeStrategy': 'append'}
+                      'mergeStrategy': 'append'
                   }}
 
         base = None


### PR DESCRIPTION
Hello!
I came across an issue when trying to merge 2 jsons where the values of arbitrary keys needed to be appended.

The schema for additional properties is slightly different than for pattern properties because it matches all additional properties and so it doesn't need to specify a rule to match, but goes straight into the details of the property.

```
'patternProperties': {
    'a.*': {'mergeStrategy'},
'additionalProperties': {
    'mergeStrategy': 'append'
}
```
I just made a small change so that for additional properties it would use the json object directly and not try to match the property. 

I didn't find a relevant example in the json schema docs, but heres one from another site:
http://spacetelescope.github.io/understanding-json-schema/reference/object.html?highlight=additionalproperties

btw this was my case, and desired output:
```
schema = {'mergeStrategy': 'objectMerge',
                  'additionalProperties': {
                      'mergeStrategy': 'append'
a = {'randomKey': [1, 2, 3]}
b = {'randomKey': [4,5],
       'anotherRandomKey': [1]}
...
merged = {'randomKey': [1, 2, 3, 4, 5],
          'anotherRandomKey': [1]}
```
please pull! thanks!
Nick