### PR TITLE
Add renameConflicts option to ObjectMerge strategy

### DIFF
--- a/jsonmerge/jsonvalue.py
+++ b/jsonmerge/jsonvalue.py
@@ -41,3 +41,9 @@ class JSONValue(object):
 
         for i, v in enumerate(self.val):
             yield self._subval(i, val=v)
+
+    def __eq__(self, other):
+        return self.val == other.val and self.ref == other.ref
+
+    def __ne__(self, other):
+        return self.val != other.val or self.ref != other.ref

--- a/tests/test_jsonvalue.py
+++ b/tests/test_jsonvalue.py
@@ -1,6 +1,8 @@
 # vim:ts=4 sw=4 expandtab softtabstop=4
 import unittest
+
 from jsonmerge.jsonvalue import JSONValue
+
 
 class TestJSONValue(unittest.TestCase):
 
@@ -37,3 +39,22 @@ class TestJSONValue(unittest.TestCase):
         va = v.get('a')
         self.assertTrue('b', va.val)
         self.assertEqual('#/a', va.ref)
+
+    def test_eq(self):
+        a = JSONValue({'a': 'b'}, '#')
+        b = JSONValue({'a': 'b'}, '#')
+        c = JSONValue({'a': 'b'}, '#/properties')
+        d = JSONValue("value", '#')
+        e = JSONValue(None, '#')
+        f = JSONValue(None, '#')
+        self.assertTrue(a == b)
+        self.assertTrue(e == f)
+        self.assertFalse(a == c)
+        self.assertFalse(a == d)
+
+    def test_ne(self):
+        a = JSONValue({'a': 'b'}, '#')
+        b = JSONValue({'a': 'b'}, '#')
+        c = JSONValue({'a': 'b'}, '#/properties')
+        self.assertTrue(a != c)
+        self.assertFalse(a != b)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-	py27-latest,py34-latest
+	py27-latest,py35-latest
 
 [testenv]
 commands = python setup.py test
@@ -8,5 +8,5 @@ commands = python setup.py test
 [testenv:py27-latest]
 basepython = python2.7
 
-[testenv:py34-latest]
-basepython = python3.4
+[testenv:py35-latest]
+basepython = python3.5


### PR DESCRIPTION
Passing `"renameConflicts": true` in `mergeOptions` will cause conflicting properties to be renamed instead of overwritten when using the `ObjectMerge` strategy. By default, the new property name of the conflicting file will be the previous property name with `'-conflict'` appended to it. The suffix and/or prefix used for renaming the conflicting property can be set using the `renameSuffix` and `renamePrefix` properties in `mergeOptions`. Anyways, neat library (discovered it a little earlier today). The only thing I was missing was the ability to rename conflicting fields. 