### PR TITLE
Provide support for alternative object classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,7 +181,7 @@ objectMerge
   *OrderedDict*, to use the ``collections.OrderedDict`` class, or *default*,
   which uses whatever class was configured as the default class
   (normally, ``dict``).  Note that additional classes can be configured in
-  via the Merger class.  
+  via the Merger class.  (OrderedDict is not available in python 2.6.)
   
 version
   Changes the type of the value to an array. New values are appended to the
@@ -210,7 +210,8 @@ data by allowing you to:
 
 - set the schema containing the merge stategy configuration
 - provide additional strategy implementations
-- set a default class to use for holding JSON object data
+- set a default class to use for holding JSON object data; OrderedDict
+  provided as built-in option (python 2.7 or later).
 - configure additional available JSON object classes
     
 The Merger constructor takes the following arguments

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,14 @@ objectMerge
   (e.g. in *properties*, *patternProperties* or *additionalProperties*
   schema keywords).
 
+  The *objclass* option allows one to request a different dictionary class
+  to be used to hold the JSON object.  The possible values are names
+  that correspond to specific Python classes.  Built-in names include
+  'OrderedDict', to use the collections.OrderedDict class, or 'default',
+  which uses whatever class was configured as the default class
+  (normally, dict).  Note that additional classes can be configured in
+  via the Merger class.  
+  
 version
   Changes the type of the value to an array. New values are appended to the
   array in the form of an object with a *value* property. This way all
@@ -191,8 +199,50 @@ If a merge strategy is not specified in the schema, *objectMerge* is used
 to objects and *overwrite* for all other values.
 
 You can implement your own strategies by making subclasses of
-jsonmerge.strategies.Strategy and passing them to Merger() constructor.
+jsonmerge.strategies.Strategy and passing them to Merger() constructor
+(see below).
 
+The Merger Class
+----------------
+
+The Merger class allows you to further customize the merging of JSON
+data by allowing you to:
+
+- set the schema containing the merge stategy configuration
+- provide additional strategy implementations
+- set a default class to use for holding JSON object data
+- configure additional available JSON object classes
+    
+The Merger constructor takes the following arguments
+
+`schema`
+   The JSON Schema that contains the merge strategy directives
+   provided as a JSON object.  An empty dictionary should be provided
+   if strategy configuration is needed.
+
+`strategies`
+   a dictionary mapping strategy names to instances of Strategy
+   classes.  These will be combined with the built-in strategies
+   (overriding them with the instances having the same name).
+
+`def_objclass`
+   the name of a supported dictionary-like class to use hold JSON
+   data by default in the merged result.  The name must match a
+   built-in name or one provided in the `obj_cls_menu` parameter.
+   Built-in names include *OrderedDict*, which will cause the
+   `collections.OrderedDict` class to be used, and *default*, which will
+   use the configured default class.  If the *default* name has not been
+   overridden by the `obj_cls_menu` parameter, which will be a vanilla
+   `dict`. 
+
+`obj_cls_menu`
+   a dictionary providing possible classes to use as JSON object
+   containers.  The keys are names that can be used as values for the
+   *objectMerge* strategy's *objclass* option (in addition to the
+   built-in *OrderedDict* and *default*).  Each value is a
+   function or class that produces an instance of the JSON object
+   container; it must support an optional dictionary-like object as a
+   parameter which initializes its contents.  
 
 Limitations
 -----------

--- a/README.rst
+++ b/README.rst
@@ -178,9 +178,9 @@ objectMerge
   The *objclass* option allows one to request a different dictionary class
   to be used to hold the JSON object.  The possible values are names
   that correspond to specific Python classes.  Built-in names include
-  'OrderedDict', to use the collections.OrderedDict class, or 'default',
+  *OrderedDict*, to use the ``collections.OrderedDict`` class, or *default*,
   which uses whatever class was configured as the default class
-  (normally, dict).  Note that additional classes can be configured in
+  (normally, ``dict``).  Note that additional classes can be configured in
   via the Merger class.  
   
 version
@@ -215,27 +215,27 @@ data by allowing you to:
     
 The Merger constructor takes the following arguments
 
-`schema`
+``schema``
    The JSON Schema that contains the merge strategy directives
    provided as a JSON object.  An empty dictionary should be provided
-   if strategy configuration is needed.
+   if no strategy configuration is needed.
 
-`strategies`
+``strategies``
    a dictionary mapping strategy names to instances of Strategy
    classes.  These will be combined with the built-in strategies
    (overriding them with the instances having the same name).
 
-`def_objclass`
+``def_objclass``
    the name of a supported dictionary-like class to use hold JSON
    data by default in the merged result.  The name must match a
-   built-in name or one provided in the `obj_cls_menu` parameter.
+   built-in name or one provided in the ``obj_cls_menu`` parameter.
    Built-in names include *OrderedDict*, which will cause the
-   `collections.OrderedDict` class to be used, and *default*, which will
+   ``collections.OrderedDict`` class to be used, and *default*, which will
    use the configured default class.  If the *default* name has not been
-   overridden by the `obj_cls_menu` parameter, which will be a vanilla
-   `dict`. 
+   overridden by the ``obj_cls_menu`` parameter, the default JSON
+   object container will be a vanilla ``dict``. 
 
-`obj_cls_menu`
+``obj_cls_menu``
    a dictionary providing possible classes to use as JSON object
    containers.  The keys are names that can be used as values for the
    *objectMerge* strategy's *objclass* option (in addition to the

--- a/jsonmerge/__init__.py
+++ b/jsonmerge/__init__.py
@@ -3,7 +3,12 @@ from jsonmerge.jsonvalue import JSONValue
 from jsonmerge import strategies
 from jsonschema.validators import Draft4Validator, RefResolver
 import logging
-from collections import OrderedDict
+
+try:
+    # OrderedDict does not exist in python 2.4
+    from collections import OrderedDict
+except:
+    OrderedDict = None
 
 log = logging.getLogger(name=__name__)
 
@@ -199,7 +204,8 @@ class Merger(object):
         uses collections.OrderedDict as an JSON object type, and 
         'default', which uses a vanilla dict.  If def_objclass is not
         set to 'default', the class associated with 'default' with the 
-        class associated with that given name.  
+        class associated with that given name.  (Note: OrderedDict not 
+        available for python 2.6.)
         """
 
         self.schema = schema
@@ -208,7 +214,9 @@ class Merger(object):
         self.strategies = dict(self.STRATEGIES)
         self.strategies.update(strategies)
 
-        self.obj_cls_menu = { 'default': dict, 'OrderedDict': OrderedDict }
+        self.obj_cls_menu = { 'default': dict }
+        if OrderedDict:
+            self.obj_cls_menu['OrderedDict'] = OrderedDict
         if obj_cls_menu:
             self.obj_cls_menu.update(obj_cls_menu)
         if def_objclass is not None and def_objclass != 'default' and def_objclass in self.obj_cls_menu:

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -221,11 +221,11 @@ class TestMerge(unittest.TestCase):
         base = None
         base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         base = merger.merge(base, {'a': "b"}, schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         self.assertEqual(base, {'a': "b", 'c': "a"})
 
@@ -240,11 +240,11 @@ class TestMerge(unittest.TestCase):
         base = None
         base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         base = merger.merge(base, {'a': "b"}, schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         self.assertEqual(base, {'a': "b", 'c': "a"})
 
@@ -258,11 +258,11 @@ class TestMerge(unittest.TestCase):
         base = None
         base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         base = merger.merge(base, {'a': "b"}, schema)
         self.assertIsInstance(base, OrderedDict)
-        self.assertEquals(base.keys(), ['c', 'a'])
+        self.assertEquals([k for k in base], ['c', 'a'])
 
         self.assertEqual(base, {'a': "b", 'c': "a"})
 

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -1,5 +1,6 @@
 # vim:ts=4 sw=4 expandtab softtabstop=4
 import unittest
+import pdb
 import jsonmerge
 import jsonmerge.strategies
 from jsonmerge.exceptions import (
@@ -209,6 +210,61 @@ class TestMerge(unittest.TestCase):
         base = jsonmerge.merge(base, {'a': "b"}, schema)
 
         self.assertEqual(base, {'a': "b"})
+
+    def test_merge_objclass(self):
+
+        from collections import OrderedDict
+        schema = {'mergeStrategy': 'objectMerge', 'mergeOptions': { 'objclass': 'OrderedDict'}}
+
+        merger = jsonmerge.Merger(schema)
+
+        base = None
+        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        base = merger.merge(base, {'a': "b"}, schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        self.assertEqual(base, {'a': "b", 'c': "a"})
+
+    def test_merge_def_objclass(self):
+
+        from collections import OrderedDict
+        schema = {'mergeStrategy': 'objectMerge'}
+        menu = { 'default': OrderedDict }
+
+        merger = jsonmerge.Merger(schema, obj_cls_menu=menu)
+
+        base = None
+        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        base = merger.merge(base, {'a': "b"}, schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        self.assertEqual(base, {'a': "b", 'c': "a"})
+
+    def test_merge_def_objclass2(self):
+
+        from collections import OrderedDict
+        schema = {'mergeStrategy': 'objectMerge'}
+
+        merger = jsonmerge.Merger(schema, def_objclass='OrderedDict')
+
+        base = None
+        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        base = merger.merge(base, {'a': "b"}, schema)
+        self.assertIsInstance(base, OrderedDict)
+        self.assertEquals(base.keys(), ['c', 'a'])
+
+        self.assertEqual(base, {'a': "b", 'c': "a"})
 
     def test_merge_append(self):
 
@@ -1436,3 +1492,7 @@ class TestGetSchema(unittest.TestCase):
         schema2 = merger.get_schema()
 
         self.assertEqual(schema2, expected)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -1,6 +1,13 @@
 # vim:ts=4 sw=4 expandtab softtabstop=4
 import unittest
 import pdb
+
+try:
+    from collections import OrderedDict
+except:
+    # OrderedDict not available in python 2.4
+    OrderedDict = None
+
 import jsonmerge
 import jsonmerge.strategies
 from jsonmerge.exceptions import (
@@ -11,7 +18,6 @@ from jsonmerge.exceptions import (
 from jsonmerge.jsonvalue import JSONValue
 
 import jsonschema
-
 
 class TestMerge(unittest.TestCase):
 
@@ -213,58 +219,58 @@ class TestMerge(unittest.TestCase):
 
     def test_merge_objclass(self):
 
-        from collections import OrderedDict
-        schema = {'mergeStrategy': 'objectMerge', 'mergeOptions': { 'objclass': 'OrderedDict'}}
+        if OrderedDict:
+            schema = {'mergeStrategy': 'objectMerge', 'mergeOptions': { 'objclass': 'OrderedDict'}}
 
-        merger = jsonmerge.Merger(schema)
+            merger = jsonmerge.Merger(schema)
 
-        base = None
-        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = None
+            base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        base = merger.merge(base, {'a': "b"}, schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = merger.merge(base, {'a': "b"}, schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        self.assertEqual(base, {'a': "b", 'c': "a"})
+            self.assertEqual(base, {'a': "b", 'c': "a"})
 
     def test_merge_def_objclass(self):
 
-        from collections import OrderedDict
-        schema = {'mergeStrategy': 'objectMerge'}
-        menu = { 'default': OrderedDict }
+        if OrderedDict:
+            schema = {'mergeStrategy': 'objectMerge'}
+            menu = { 'default': OrderedDict }
 
-        merger = jsonmerge.Merger(schema, obj_cls_menu=menu)
+            merger = jsonmerge.Merger(schema, obj_cls_menu=menu)
 
-        base = None
-        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = None
+            base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        base = merger.merge(base, {'a': "b"}, schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = merger.merge(base, {'a': "b"}, schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        self.assertEqual(base, {'a': "b", 'c': "a"})
+            self.assertEqual(base, {'a': "b", 'c': "a"})
 
     def test_merge_def_objclass2(self):
 
-        from collections import OrderedDict
-        schema = {'mergeStrategy': 'objectMerge'}
+        if OrderedDict:
+            schema = {'mergeStrategy': 'objectMerge'}
 
-        merger = jsonmerge.Merger(schema, def_objclass='OrderedDict')
+            merger = jsonmerge.Merger(schema, def_objclass='OrderedDict')
 
-        base = None
-        base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = None
+            base = merger.merge(base, OrderedDict([('c', "a"), ('a', "a")]), schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        base = merger.merge(base, {'a': "b"}, schema)
-        self.assertIsInstance(base, OrderedDict)
-        self.assertEquals([k for k in base], ['c', 'a'])
+            base = merger.merge(base, {'a': "b"}, schema)
+            self.assertIsInstance(base, OrderedDict)
+            self.assertEquals([k for k in base], ['c', 'a'])
 
-        self.assertEqual(base, {'a': "b", 'c': "a"})
+            self.assertEqual(base, {'a': "b", 'c': "a"})
 
     def test_merge_append(self):
 


### PR DESCRIPTION
The main motivation for this PR is to provide a way to have `jsonmerge` to use the `OrderedDict` class for JSON object data in the merged result.  This is analogous to the [`json`  package's support for the `object_pairs_hook` parameter](https://docs.python.org/2.7/library/json.html#json.load).  And like that `json` parameter, this PR tries to generalize the ability to customize the JSON object class.  

The changes in the interfaces occur in the `Merger` class and the `ObjectMerge` strategy class.  The Merger class has built-in options for using either `dict` or `OrderedDict`, so the easiest way to use the latter throughout the merged result is to set the constructor's `objclass` parameter to `'OrderedDict'`.  

This PR also allows one to set the object class on a per JSON object type level.  This is done via the `objclass` _mergeOption_ to the _objectMerge_ strategy.  Setting this option can be set to either `'OrderedDict'` or `'default'` to have `ObjectMerge` or `dict` used as an object container for that type.  Other classes can be made available to this option by providing a dictionary of class via the `Merger` constructor's `obj_cls_menu`.

For full details, see the new text added to the README.rst and inline documentation for the `Merger` and `ObjectMerge` class.  This PR includes some added tests.  

