### PR TITLE
Support 'allOf' and 'anyOf' with overwrite strategies

### DIFF
--- a/jsonmerge/__init__.py
+++ b/jsonmerge/__init__.py
@@ -93,7 +93,9 @@ class WalkInstance(Walk):
         return rv
 
     def default_strategy(self, schema, base, head, meta, **kwargs):
-        if self.is_type(head, "object"):
+        if not schema.is_undef() and ("anyOf" in schema.val or "allOf" in schema.val):
+            return "overwrite"
+        elif self.is_type(head, "object"):
             return "objectMerge"
         else:
             return "overwrite"

--- a/jsonmerge/__init__.py
+++ b/jsonmerge/__init__.py
@@ -93,9 +93,7 @@ class WalkInstance(Walk):
         return rv
 
     def default_strategy(self, schema, base, head, meta, **kwargs):
-        if not schema.is_undef() and ("anyOf" in schema.val or "allOf" in schema.val):
-            return "overwrite"
-        elif self.is_type(head, "object"):
+        if self.is_type(head, "object"):
             return "objectMerge"
         else:
             return "overwrite"

--- a/jsonmerge/descenders.py
+++ b/jsonmerge/descenders.py
@@ -94,7 +94,6 @@ class OneOf(Descender):
 
 class AnyOfAllOf(Descender):
     def descend_instance(self, walk, schema, base, head, meta):
-
         allOf = schema.get("allOf")
         anyOf = schema.get("anyOf")
         if allOf.is_undef() and anyOf.is_undef():
@@ -103,42 +102,7 @@ class AnyOfAllOf(Descender):
         if schema.val.get("mergeStrategy") == "overwrite":
             return None
 
-        anyall = allOf if anyOf.is_undef() else anyOf
-
-        def is_valid(v, schema):
-            if v.is_undef():
-                return True
-            else:
-                return not list(walk.merger.validator.iter_errors(v.val, schema))
-
-        base_valid = []
-        head_valid = []
-
-        for i, subschema in enumerate(anyall.val):
-            if is_valid(base, subschema):
-                base_valid.append(i)
-            if is_valid(head, subschema):
-                head_valid.append(i)
-
-        if not anyOf.is_undef():
-            if len(base_valid) == 0:
-                raise BaseInstanceError("No element of 'anyOf' validates base")
-            if len(head_valid) == 0:
-                raise HeadInstanceError("No element of 'anyOf' validates head")
-        else:
-            if len(base_valid) < len(allOf.val):
-                raise BaseInstanceError("Not all elements of 'allOf' validate base")
-            if len(head_valid) < len(allOf.val):
-                raise HeadInstanceError("Not all elements of 'allOf' validate head")
-
-        for i in head_valid:
-            subschema = anyall.val[i]
-            strategy = subschema.get("mergeStrategy") \
-                    or walk.default_strategy(JSONValue(subschema), base, head, meta)
-            if strategy != "overwrite":
-                raise SchemaError("Can't descend to 'allOf' and 'anyOf' keywords")
-
-        return None
+        raise SchemaError("Can't descend to 'allOf' and 'anyOf' keywords")
 
     def descend_schema(self, walk, schema, meta):
         allOf = schema.get("allOf")
@@ -149,11 +113,4 @@ class AnyOfAllOf(Descender):
         if schema.val.get("mergeStrategy") == "overwrite":
             return schema
 
-        anyall = allOf if anyOf.is_undef() else anyOf
-        for subschema in anyall.val:
-            strategy = subschema.get("mergeStrategy") \
-                    or walk.default_strategy(JSONValue(subschema), meta)
-            if strategy != "overwrite":
-                raise SchemaError("Can't descend to 'allOf' and 'anyOf' keywords")
-
-        return schema
+        raise SchemaError("Can't descend to 'allOf' and 'anyOf' keywords")

--- a/jsonmerge/descenders.py
+++ b/jsonmerge/descenders.py
@@ -58,6 +58,9 @@ class OneOf(Descender):
         if one_of.is_undef():
             return None
 
+        if schema.val.get("mergeStrategy") == "overwrite":
+            return None
+
         valid = []
 
         def is_valid(v, schema):

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -504,6 +504,24 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, {"a": ["1", "2"], "b": "4", "g": "7", "c": {"d": ["4", "3"], "e": "f"}})
 
+    def test_oneof_overwrite_toplevel(self):
+        schema = {
+            'mergeStrategy': 'overwrite',
+            'oneOf': [
+                {
+                    'type': 'array'
+                },
+                {
+                    'type': 'string'
+                },
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+
+        self.assertEqual(merger.merge([2, 3, 4], 'a'), 'a')
+        self.assertEqual(merger.merge('a', [2, 3, 4]), [2, 3, 4])
+
     def test_anyof_overwrite_toplevel(self):
         schema = {
             'mergeStrategy': 'overwrite',

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -504,6 +504,28 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, {"a": ["1", "2"], "b": "4", "g": "7", "c": {"d": ["4", "3"], "e": "f"}})
 
+    def test_anyof(self):
+        schema = {
+            'anyOf': [
+                {
+                    'mergeStrategy': 'overwrite'
+                },
+                {
+                    'type': 'array'
+                },
+                {
+                    'type': 'string'
+                },
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+
+        self.assertEqual(merger.merge('a', {'a': 1}), {'a': 1})
+        self.assertEqual(merger.merge({'a': 1}, 'a'), 'a')
+        self.assertEqual(merger.merge([2, 3, 4], 'a'), 'a')
+        self.assertEqual(merger.merge('a', [2, 3, 4]), [2, 3, 4])
+
     def test_custom_strategy(self):
 
         schema = {'mergeStrategy': 'myStrategy'}
@@ -1208,7 +1230,7 @@ class TestGetSchema(unittest.TestCase):
                              }
                          })
 
-    def test_anyof(self):
+    def test_anyof_descend(self):
         # We don't support descending through 'anyOf', since each branch could
         # have its own rules for merging. How could we then decide which rule
         # to follow?
@@ -1261,6 +1283,21 @@ class TestGetSchema(unittest.TestCase):
         merger = jsonmerge.Merger(schema)
         mschema = merger.get_schema()
         self.assertEqual(expected, mschema)
+
+    def test_anyof_overwrite_all(self):
+        # 'anyOf' should also be fine if all possible subschemas would result in
+        # an 'overwrite' strategy.
+
+        schema = {
+            'anyOf': [
+                {'mergeStrategy': 'overwrite'},
+                {'type': 'array'},
+                {'type': 'string'}
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+        mschema = merger.get_schema()
 
     def test_external_refs(self):
 

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -504,12 +504,10 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, {"a": ["1", "2"], "b": "4", "g": "7", "c": {"d": ["4", "3"], "e": "f"}})
 
-    def test_anyof(self):
+    def test_anyof_overwrite_toplevel(self):
         schema = {
+            'mergeStrategy': 'overwrite',
             'anyOf': [
-                {
-                    'mergeStrategy': 'overwrite'
-                },
                 {
                     'type': 'array'
                 },
@@ -521,8 +519,6 @@ class TestMerge(unittest.TestCase):
 
         merger = jsonmerge.Merger(schema)
 
-        self.assertEqual(merger.merge('a', {'a': 1}), {'a': 1})
-        self.assertEqual(merger.merge({'a': 1}, 'a'), 'a')
         self.assertEqual(merger.merge([2, 3, 4], 'a'), 'a')
         self.assertEqual(merger.merge('a', [2, 3, 4]), [2, 3, 4])
 
@@ -1283,21 +1279,6 @@ class TestGetSchema(unittest.TestCase):
         merger = jsonmerge.Merger(schema)
         mschema = merger.get_schema()
         self.assertEqual(expected, mschema)
-
-    def test_anyof_overwrite_all(self):
-        # 'anyOf' should also be fine if all possible subschemas would result in
-        # an 'overwrite' strategy.
-
-        schema = {
-            'anyOf': [
-                {'mergeStrategy': 'overwrite'},
-                {'type': 'array'},
-                {'type': 'string'}
-            ]
-        }
-
-        merger = jsonmerge.Merger(schema)
-        mschema = merger.get_schema()
 
     def test_external_refs(self):
 


### PR DESCRIPTION
If a schema containing an 'allOf'/'anyOf' keyword has an 'overwrite' strategy, or if all the subschemas of the keyword have 'overwrite' strategies themselves (explicitly or by default), the keywords don't need to be descended and the instances may be safely merged.

This came up in some complex schemas we had at work and I thought it might be useful to a wider audience. I'm not entirely sure I went with the best approach; if you feel this should be refactored in some way just point me in the right direction!