### PR TITLE
Fix for arrayMergeById when iterator oversteps merge item

### DIFF
--- a/jsonmerge/strategies.py
+++ b/jsonmerge/strategies.py
@@ -26,7 +26,7 @@ class Strategy(object):
 
         The function should return the object resulting from the merge.
 
-        Recursion into the next level, if necessary, is achieved by calling
+        Recursioninto the next level, if necessary, is achieved by calling
         walk.descend() method.
         """
         raise NotImplemented
@@ -175,11 +175,12 @@ class ArrayMergeById(Strategy):
 
                 if base_key == head_key:
                     matching_j.append(j)
+                    matched_item = base_item
 
             if len(matching_j) == 1:
                 # If there was exactly one match, we replace it with a merged item
                 j = matching_j[0]
-                base[j] = walk.descend(subschema, base_item, head_item, meta)
+                base[j] = walk.descend(subschema, matched_item, head_item, meta)
             elif len(matching_j) == 0:
                 # If there wasn't a match, we append a new object
                 base.append(walk.descend(subschema, JSONValue(undef=True), head_item, meta))
@@ -204,7 +205,7 @@ class ObjectMerge(Strategy):
     properties that are present both in base and head are merged based
     on the strategy specified further down in the hierarchy (e.g. in
     properties, patternProperties or additionalProperties schema
-    keywords). 
+    keywords).
 
     walk -- WalkInstance object for the current context.
     base -- JSONValue being merged into.

--- a/jsonmerge/strategies.py
+++ b/jsonmerge/strategies.py
@@ -26,7 +26,7 @@ class Strategy(object):
 
         The function should return the object resulting from the merge.
 
-        Recursioninto the next level, if necessary, is achieved by calling
+        Recursion into the next level, if necessary, is achieved by calling
         walk.descend() method.
         """
         raise NotImplemented
@@ -205,7 +205,7 @@ class ObjectMerge(Strategy):
     properties that are present both in base and head are merged based
     on the strategy specified further down in the hierarchy (e.g. in
     properties, patternProperties or additionalProperties schema
-    keywords).
+    keywords). 
 
     walk -- WalkInstance object for the current context.
     base -- JSONValue being merged into.

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -633,8 +633,8 @@ class TestMerge(unittest.TestCase):
 
         b = {
             "awards": [
-                {"id": "B", "field": 3},
-                {"id": "C", "field": 4}
+                {"id": "C", "field": 4},
+                {"id": "B", "field": 3}
             ]
         }
 


### PR DESCRIPTION

Under certain circumstances the arrayMergeById strategy fails with and "Unresolvable JSON pointer" error. It depends entirely on the structure of the base and head JSON that is used. 

I was able to recreate the bug with a single line change to the existing tests for arrayMergeById. By reordering the head items in that test we get the failure below.

The problem is that as the code iterates over head and base arrays while matching it can step over a matched item and then try and merge the wrong item.

By recording the matched item we can avoid this. 

@avian2 Could you let me know if this PR is acceptable and when you might be able to make a new release with it. I am currently having to carefully construct JSON to avoid this issue.

The easiest way to reproduce is to apply my change to the test first and rerun the tests. The change in strategies.py will then fix the failed test.

Regards

Fergal

**Error output from test run :**
`
Traceback (most recent call last):
  File "/Users/fdearle/github/jsonmerge/tests/test_jsonmerge.py", line 653, in test_merge_by_id
    base = merger.merge(base, b)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 288, in merge
    return walk.descend(schema, base, head, meta).val
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 80, in descend
    rv = self.work(strategy, schema, *args, **opts)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 125, in work
    rv = strategy.merge(self, base, head, schema, meta, objclass_menu=self.merger.objclass_menu, **kwargs)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/strategies.py", line 269, in merge
    base[k] = walk.descend(subschema, base.get(k), v, meta)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 80, in descend
    rv = self.work(strategy, schema, *args, **opts)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 125, in work
    rv = strategy.merge(self, base, head, schema, meta, objclass_menu=self.merger.objclass_menu, **kwargs)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/strategies.py", line 182, in merge
    base[j] = walk.descend(subschema, base_item, head_item, meta)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 80, in descend
    rv = self.work(strategy, schema, *args, **opts)
  File "/Users/fdearle/github/jsonmerge/jsonmerge/__init__.py", line 118, in work
    with self.base_resolver.resolving(base.ref) as resolved:
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/Library/Python/2.7/site-packages/jsonschema/validators.py", line 366, in resolving
    url, resolved = self.resolve(ref)
  File "/Library/Python/2.7/site-packages/jsonschema/validators.py", line 375, in resolve
    return url, self._remote_cache(url)
  File "/Library/Python/2.7/site-packages/jsonschema/validators.py", line 387, in resolve_from_url
    return self.resolve_fragment(document, fragment)
  File "/Library/Python/2.7/site-packages/jsonschema/validators.py", line 421, in resolve_fragment
    "Unresolvable JSON pointer: %r" % fragment
RefResolutionError: Unresolvable JSON pointer: u'awards/2'
`