### PR TITLE
allowing sorting as an option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,6 +229,9 @@ discard
 append
   Append arrays. Works only with arrays.
 
+  You can specify an optional *sortBy* parameter to indicate the key that 
+  should be used to alphabetically sort a complex structure.
+
 arrayMergeById
   Merge arrays, identifying items to be merged by an ID field. Resulting
   arrays have items from both *base* and *head* arrays.  Any items that
@@ -255,6 +258,9 @@ arrayMergeById
   object in *head*, the object is ignored. If using an array for *idRef*
   and if *ignoreId* option is also defined, *ignoreId* must be an array as
   well.
+
+  You can specify an optional *sortBy* parameter to indicate the key that 
+  should be used to alphabetically sort a complex structure.
 
 arrayMergeByIndex
   Merge array items by their index in the array. Similarly to

--- a/jsonmerge/strategies.py
+++ b/jsonmerge/strategies.py
@@ -140,7 +140,7 @@ class Version(Strategy):
         return JSONValue(rv, schema.ref)
 
 class Append(Strategy):
-    def merge(self, walk, base, head, schema, **kwargs):
+    def merge(self, walk, base, head, schema, sortBy=None, **kwargs):
         if not walk.is_type(head, "array"):
             raise HeadInstanceError("Head is not an array", head)
 
@@ -153,6 +153,8 @@ class Append(Strategy):
             base = JSONValue(list(base.val), base.ref)
 
         base.val += head.val
+        if sortBy != None:
+            base.val.sort(key = lambda i: i[sortBy])
         return base
 
     def get_schema(self, walk, schema, **kwargs):
@@ -181,7 +183,7 @@ class ArrayMergeById(Strategy):
 
             yield i, key, item
 
-    def merge(self, walk, base, head, schema, idRef="id", ignoreId=None, **kwargs):
+    def merge(self, walk, base, head, schema, idRef="id", ignoreId=None, sortBy=None, **kwargs):
         if not walk.is_type(head, "array"):
             raise HeadInstanceError("Head is not an array", head)  # nopep8
 
@@ -227,6 +229,9 @@ class ArrayMergeById(Strategy):
             else:
                 j = matching_j[1]
                 raise BaseInstanceError("Id '%s' was not unique in base" % (base_key,), base[j])
+
+        if sortBy != None:
+            base.val.sort(key = lambda i: i[sortBy])
 
         return base
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 setup(name='jsonmerge',
-    version='1.7.0',
+    version='1.7.1',
     description='Merge a series of JSON documents.',
     license='MIT',
     long_description=open("README.rst").read(),

--- a/tests/test_jsonmerge.py
+++ b/tests/test_jsonmerge.py
@@ -195,6 +195,26 @@ class TestMerge(unittest.TestCase):
 
         self.assertEqual(base, ["a", "b"])
 
+    def test_append_with_sort(self):
+        schema = {'mergeStrategy': 'append', 
+                  'mergeOptions': 
+                  { 'sortBy': 'name'}}
+
+        base = None
+        head = [{"name": "b"}, {"name": "a"}]
+        base = jsonmerge.merge(base, head , schema)
+        
+        self.assertEqual(base, [{"name": "a"}, {"name": "b"}])
+
+    def test_append_and_sort_no_sortBy_option_defined(self):
+        schema = {'mergeStrategy': 'append'}
+
+        base = None
+        head = [{"name": "b"}, {"name": "a"}]
+        base = jsonmerge.merge(base, head , schema)
+        
+        self.assertEqual(base, [{"name": "b"}, {"name": "a"}])
+
     def test_append_type_error(self):
 
         schema = {'mergeStrategy': 'append'}
@@ -2330,6 +2350,55 @@ class TestGetSchema(unittest.TestCase):
         schema2 = merger.get_schema()
 
         self.assertEqual(schema2, expected)
+
+    def test_merge_by_id_with_sort(self):
+        schema = {
+            "properties": {
+                "awards": {
+                    "type": "array",
+                    "mergeStrategy": "arrayMergeById",
+                    'mergeOptions': 
+                        { 'sortBy': 'id'},
+                    "items": {
+                        "properties": {
+                            "id": {"type": "string"},
+                            "field": {"type": "number"},
+                        }
+                    }
+                }
+            }
+        }
+
+        a = {
+            "awards": [
+                {"id": "B", "field": 3},
+                {"id": "A", "field": 2}
+            ]
+        }
+
+        b = {
+            "awards": [
+                {"id": "C", "field": 4},
+                {"id": "B", "field": 3}
+            ]
+        }
+
+        expected = {
+            "awards": [
+                {"id": "A", "field": 2},
+                {"id": "B", "field": 3},
+                {"id": "C", "field": 4}
+            ]
+        }
+
+        merger = jsonmerge.Merger(schema)
+
+        base = None
+        base = merger.merge(base, a)
+        base = merger.merge(base, b)
+
+        self.assertEqual(base, expected)
+
 
     def test_merge_append_additional(self):
 


### PR DESCRIPTION
This PR adds an option to sort complex arrays based on a key when the merge strategy is either append or arrayMergeById